### PR TITLE
Merge in lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ get_pdf
 get_jpg
 get_jpg_techmd
 get_limb_ocr
-get_jej_ocr
 get_pos_ocr
 get_descriptive_metadata
 ```
 
-Further information on the StorageInterface classes, and the expected method behavior, can be found [in the digcollretriever_lib repository](https://github.com/uchicago-library/digcollretriever_lib)
+To implement a new StorageInterface class navigate to the digcollretriever.lib.storageinterfaces module and write a new child class inheriting from StorageInterface. The StorageInterface class itself defines the method footprint and individual method signatures and return values which are expected by the digcollretriever API.
 
+Functionality from StorageInterface not overloaded will signal to the API that it can attempt to use fallback methods in order to satisfy the request (by raising an instance of digcollretriever.lib.exceptions.Omitted). If you wish to prevent fallbacks implement a method with the same footprint which raises an exception which is not an instance of digcollretriever_lib.exceptions.Omitted.
 
 Image used in tests originally from https://www.flickr.com/photos/fannydesbaumes/35263390573/in/photostream/ CCSA

--- a/digcollretriever/blueprint/__init__.py
+++ b/digcollretriever/blueprint/__init__.py
@@ -7,10 +7,10 @@ from flask_restful import Resource, Api, reqparse
 
 from PIL import Image
 
+from .lib.storageinterfaces import StorageInterface
 from .lib import determine_identifier_type, sane_transform_args, \
     should_transform, general_transform
-from digcollretriever_lib.storageinterfaces import StorageInterface
-from digcollretriever_lib.exceptions import Error, Omitted
+from .lib.exceptions import Error, Omitted
 
 BLUEPRINT = Blueprint('digcollretriever', __name__)
 

--- a/digcollretriever/blueprint/lib/__init__.py
+++ b/digcollretriever/blueprint/lib/__init__.py
@@ -2,8 +2,8 @@ import logging
 import sys
 import inspect
 from math import floor
-from digcollretriever_lib.exceptions import MutuallyExclusiveParametersError
-from digcollretriever_lib.storageinterfaces import *
+from .exceptions import MutuallyExclusiveParametersError
+from .storageinterfaces import *
 
 log = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ def determine_identifier_type(identifier, omits=[], includes=[]):
     """
     id_types = [
         x[1] for x in inspect.getmembers(
-            sys.modules['digcollretriever_lib.storageinterfaces'],
+            sys.modules['digcollretriever.blueprint.lib.storageinterfaces'],
             inspect.isclass
         )
     ]

--- a/digcollretriever/blueprint/lib/exceptions.py
+++ b/digcollretriever/blueprint/lib/exceptions.py
@@ -1,0 +1,63 @@
+class Omitted(Exception):
+    """
+    Descendants of StorageInterface raise this when a
+    particular functionality hasn't been implemented
+    deliberately in order to trigger fall through functionalities.
+    If you want to completely prevent fall throughs raise something
+    that isn't this exception in the method.
+
+    eg:
+
+    class YesFallThroughBehavior(StorageInterface):
+        # This class will produce tifs from jpgs
+        def __init__(self, config):
+            pass
+
+        def get_jpg(self, identifier):
+            return "/jpgs/this_one.jpg"
+
+    class NoFallThroughBehavior(StorageInterface):
+        # This class wont produce tifs from jpgs
+        def __init__(self, config):
+            pass
+
+        def get_tif(self, identifier):
+            raise NotImplementedError()
+
+        def get_jpg(self, identifier):
+            return "/jpgs/this_one.jpg"
+    """
+    pass
+
+
+class Error(Exception):
+    err_name = "Error"
+    status_code = 500
+    message = ""
+
+    def __init__(self, message=None):
+        if message is not None:
+            self.message = message
+
+    def to_dict(self):
+        return {"message": self.message,
+                "error_name": self.err_name}
+
+
+class UnknownIdentifierFormatError(Error):
+    err_name = "UnknownIdentifierFormatError"
+    message = "No handlers found for that identifier"
+
+
+class UnsupportedContextError(Error):
+    err_name = "UnsupportedContextError"
+    message = "That context isn't supported for this endpoint!"
+
+
+class ContextError(Error):
+    err_name = "ContextError"
+    message = "Something went wrong trying to access that context!"
+
+
+class MutuallyExclusiveParametersError(Error):
+    err_name = "MutuallyExclusiveParametersError"

--- a/digcollretriever/blueprint/lib/schemas.py
+++ b/digcollretriever/blueprint/lib/schemas.py
@@ -1,0 +1,33 @@
+# Schema for validating responses from the technical metadata endpoints
+techmd_schema = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "width": {"type": "integer"},
+        "height":  {"type": "integer"}
+    },
+}
+
+# Schema for validating responses from the stat endpoints
+stat_schema = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "identifier": {"type": "string",
+                       "pattern": "^.+$"},
+        "contexts_available": {"type": "array",
+                               "items": {"type": "string",
+                                         "pattern": "^.*$"},
+                               "minItems": 0}
+    }
+}
+
+# Schema for validating responses from the root endpoint
+root_schema = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "status": {"type": "string",
+                  "pattern": "^Not broken!$"}
+    }
+}

--- a/digcollretriever/blueprint/lib/storageinterfaces.py
+++ b/digcollretriever/blueprint/lib/storageinterfaces.py
@@ -1,0 +1,297 @@
+from .exceptions import Omitted
+from os.path import join
+import re
+from PIL import Image
+
+# NOTE: When implementing your identifier schema be sure that the set of
+# all valid identifiers from other schemas is disjoint from the set of
+# valid identifiers in your schema.
+# Also probably don't get too greedy with taking up the good "namespaces".
+
+
+class StorageInterface:
+    """
+    A base class for StorageInterface classes to inherit from.
+    Provides convenience methods which raise dicollretriever_lib.exceptions.Omitted.
+    Provides method signatures and documentation in each method pertaining
+    to implementing said method in your own subclass
+    """
+    @classmethod
+    def claim_identifier(cls, identifier):
+        """
+        Must be either a static or class method which returns boolean True
+        in instances where the interface class can/should handle an identifier,
+        and otherwise boolean False
+
+        __Args__
+
+        1) identifier (str): An identifier
+
+        __Return Values__
+
+        * (bool): A boolean representation of whether or not this StorageInterface
+            should be used to handle requests pertaining to the identifier.
+        """
+        return False
+
+    def __init__(self, conf):
+        """
+        Instantiates an instance of the StorageInterface class.
+
+        __Args__
+        1) conf (dict): The configuration dictionary from the API. Will include
+            all relevant environmental variables provided to the API at runtime.
+        """
+        raise NotImplementedError()
+
+    def get_tif(self, identifier):
+        """
+        Return a tif image, or raise Omitted to trigger fallback functionality
+
+        __Args__
+        1) identifier (str): The identifier of the tif
+
+        __Return Values__
+        * a filepath (str/bytes) to a tif file on disk
+        * OR
+        * a file-like object containing the tif data
+        """
+        raise Omitted()
+
+    def get_tif_techmd(self, identifier):
+        """
+        Returns a dict providing metadata about a tif
+        which exists natively (eg, is not created dynamically), which
+        minimally satisfies the following schema when serialized to JSON:
+
+        {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "properties": {
+                "width": {"type": "int"},
+                "height": {"type": "int"}
+            }
+        }
+
+        Width and height should be the dimensions of the image in pixels.
+
+        __Args__
+        1) identifier (str): The identifier of the tif
+
+        __Return Values__
+        * (dict) The dictionary as described above.
+        """
+        raise Omitted()
+
+    def get_pdf(self, identifier):
+        """
+        Return a pdf file, or raise Omitted to trigger fallback functionality
+        """
+        raise Omitted()
+
+    def get_jpg(self, identifier):
+        """
+        Return a jpg file, or raise Omitted to trigger fallback functionality
+
+        __Args__
+        1) identifier (str): The identifier of the jpg
+
+        __Return Values__
+        * a filepath (str/bytes) to a jpg file on disk
+        * OR
+        * a file-like object containing the jpg data
+        """
+        raise Omitted()
+
+    def get_jpg_techmd(self, identifier):
+        """
+        Returns a dict providing metadata about a jpg
+        which exists natively (eg, is not created dynamically), which
+        minimally satisfies the following schema when serialized to JSON:
+
+        {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "type": "object",
+            "properties": {
+                "width": {"type": "int"},
+                "height": {"type": "int"}
+            }
+        }
+
+        Width and height should be the dimensions of the image in pixels.
+
+        __Args__
+        1) identifier (str): The identifier of the jpg
+
+        __Return Values__
+        * (dict) The dictionary as described above.
+        """
+        raise Omitted()
+
+    def get_limb_ocr(self, identifier):
+        """
+        # TODO
+        """
+        raise Omitted()
+
+    def get_pos_ocr(self, identifier):
+        """
+        # TODO
+        """
+        raise Omitted()
+
+    def get_descriptive_metadata(self, identifier):
+        """
+        Returns DublinCore XML descriptive metadata about an intellectual unit
+
+        # TODO flesh this out more, generate real DC specification?
+
+        __Args__
+        1) identifier (str): The identifier of the intellectual unit
+
+        __Return Values__
+        * (filepath/file like object) a DC xml record
+        """
+        raise Omitted()
+
+
+class FlatTifDirStorageInterface(StorageInterface):
+    """
+    An example implementation of another storage interface class.
+    This one will take a directory full of tifs with only lowercase
+    letters and numbers in their file names and serve them as tifs
+    and jpgs via the web interface.
+    """
+    @classmethod
+    def claim_identifier(cls, identifier):
+        if re.match("^flattifdir-[a-z0-9]+$", identifier):
+            return True
+
+    def __init__(self, conf):
+        self.root = conf['FLAT_TIF_DIR_ROOT']
+
+    def get_tif(self, identifier):
+        return join(self.root, identifier[11:] + ".tif")
+
+
+class FlatJpgDirStorageInterface(StorageInterface):
+    """
+    An example implementation of another storage interface class.
+    This one will take a directory full of jpgs with only lowercase
+    letters and numbers in their file names and serve them as tifs
+    and jpgs via the web interface.
+    """
+    @classmethod
+    def claim_identifier(cls, identifier):
+        if re.match("^flatjpgdir-[a-z0-9]+$", identifier):
+            return True
+
+    def __init__(self, conf):
+        self.root = conf['FLAT_JPG_DIR_ROOT']
+
+    def get_jpg(self, identifier):
+        return join(self.root, identifier[11:] + ".jpg")
+
+
+class FlatJpgDirNoBadTifsStorageInterface(FlatJpgDirStorageInterface):
+    """
+    A subclass of the above, which will refuse to produce tifs
+    from jpgs dynamically
+    """
+    @classmethod
+    def claim_identifier(cls, identifier):
+        if re.match("^flatjpgdirnobadtifs-[a-z0-9]+$", identifier):
+            return True
+
+    def get_tif(self, identifier):
+        raise NotImplementedError()
+
+
+class MvolLayer1StorageInterface(StorageInterface):
+    @classmethod
+    def claim_identifier(cls, identifier):
+        if re.match("^mvol-[0-9]{4}$", identifier):
+            return True
+
+    def __init__(self, conf):
+        pass
+
+
+class MvolLayer2StorageInterface(StorageInterface):
+    @classmethod
+    def claim_identifier(cls, identifier):
+        if re.match("^mvol-[0-9]{4}-[0-9]{4}$", identifier):
+            return True
+
+    def __init__(self, conf):
+        pass
+
+
+class MvolLayer3StorageInterface(StorageInterface):
+    @classmethod
+    def claim_identifier(cls, identifier):
+        if re.match("^mvol-[0-9]{4}-[0-9]{4}-[0-9]{4}$", identifier):
+            return True
+
+    def __init__(self, conf):
+        self.MVOL_OWNCLOUD_ROOT = conf['MVOL_OWNCLOUD_ROOT']
+        self.MVOL_OWNCLOUD_USER = conf['MVOL_OWNCLOUD_USER']
+        self.MVOL_OWNCLOUD_SUBPATH = conf['MVOL_OWNCLOUD_SUBPATH']
+
+    def build_dir_path(self, identifier):
+        return join(
+            self.MVOL_OWNCLOUD_ROOT,
+            "data",
+            self.MVOL_OWNCLOUD_USER,
+            "files",
+            self.MVOL_OWNCLOUD_SUBPATH,
+            "mvol",
+            identifier.split("-")[1],
+            identifier.split("-")[2],
+            identifier.split("-")[3]
+        )
+
+    def get_pdf(self, identifier):
+        return join(self.build_dir_path(identifier), identifier+".pdf")
+
+    def get_descriptive_metadata(self, identifier):
+        return join(self.build_dir_path(identifier), identifier+".dc.xml")
+
+
+class MvolLayer4StorageInterface(StorageInterface):
+    @classmethod
+    def claim_identifier(cls, identifier):
+        if re.match("^mvol-[0-9]{4}-[0-9]{4}-[0-9]{4}_[0-9]{4}$", identifier):
+            return True
+
+    def __init__(self, conf):
+        self.MVOL_OWNCLOUD_ROOT = conf['MVOL_OWNCLOUD_ROOT']
+        self.MVOL_OWNCLOUD_USER = conf['MVOL_OWNCLOUD_USER']
+        self.MVOL_OWNCLOUD_SUBPATH = conf['MVOL_OWNCLOUD_SUBPATH']
+
+    def build_dir_path(self, identifier):
+        return join(
+            self.MVOL_OWNCLOUD_ROOT,
+            "data",
+            self.MVOL_OWNCLOUD_USER,
+            "files",
+            self.MVOL_OWNCLOUD_SUBPATH,
+            "mvol",
+            identifier.split("-")[1],
+            identifier.split("-")[2],
+            identifier.split("-")[3].split("_")[0]
+        )
+
+    def get_tif(self, identifier):
+        return join(self.build_dir_path(identifier), "TIFF", identifier+".tif")
+
+    def get_tif_techmd(self, identifier):
+        tif = Image.open(self.get_tif(identifier))
+        width, height = tif.size
+        return {"width": width, "height": height}
+
+    def get_limb_ocr(self, identifier):
+        return join(self.build_dir_path(identifier), "ALTO", identifier+".xml")
+
+    def get_pos_ocr(self, identifier):
+        pass

--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,11 @@ setup(
         exclude = [
         ]
     ),
-    dependency_links = [
-        'https://github.com/uchicago-library/digcollretriever_lib' +
-        '/tarball/master#egg=digcollretriever_lib'
-    ],
     install_requires = [
         'flask>0',
         'flask_env',
         'flask_restful',
         'jsonschema',
-        'pillow',
-        'digcollretriever_lib'
+        'pillow'
     ],
 )

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ import jsonschema
 # to the tests setUp() function
 environ['DIGCOLL_RETRIEVER_DEFER_CONFIG'] = "True"
 import digcollretriever
-from digcollretriever_lib.schemas import \
+from digcollretriever.blueprint.lib.schemas import \
     techmd_schema, stat_schema, root_schema
 
 


### PR DESCRIPTION
Merges code previously separated out into a library repository in order to streamline work into the future on the retriever.

Code was moved into a submodule (digcollretriever.blueprint.lib) and minimal changes were made to the import functionality in order to keep everything working as intended. READMEs were merged to maintain available information. The gitignore was slightly tweaked (to keep the module named lib).