### PR TITLE
MVOL Changes, README Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,7 @@ Returns the DC metadata
 * DIGCOLLRETRIEVER_VERBOSITY: Controls the logging verbosity
 
 ## MVOL Owncloud Implementation Required Env Vars
-* DIGCOLLRETRIEVER_MVOL_OWNCLOUD_ROOT: The root path for the owncloud installation holding the mvols
-* DIGCOLLRETRIEVER_MVOL_OWNCLOUD_USER: The username of the owncloud account which holds the publication shares for the files
-* DIGCOLLRETRIEVER_MVOL_OWNCLOUD_SUBPATH: Any subpath below the mvol user account which needs to be traversed before hitting the mvol specification file structure
+* DIGCOLLRETRIEVER_MVOL_ROOT: The path to the directory that contains the ```mvol``` dir
 
 ### Developing a New Endpoint
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ get_pdf
 get_jpg
 get_jpg_techmd
 get_limb_ocr
-get_pos_ocr
 get_descriptive_metadata
 ```
 

--- a/digcollretriever/blueprint/lib/storageinterfaces.py
+++ b/digcollretriever/blueprint/lib/storageinterfaces.py
@@ -229,17 +229,11 @@ class MvolLayer3StorageInterface(StorageInterface):
             return True
 
     def __init__(self, conf):
-        self.MVOL_OWNCLOUD_ROOT = conf['MVOL_OWNCLOUD_ROOT']
-        self.MVOL_OWNCLOUD_USER = conf['MVOL_OWNCLOUD_USER']
-        self.MVOL_OWNCLOUD_SUBPATH = conf['MVOL_OWNCLOUD_SUBPATH']
+        self.MVOL_ROOT = conf['MVOL_ROOT']
 
     def build_dir_path(self, identifier):
         return join(
-            self.MVOL_OWNCLOUD_ROOT,
-            "data",
-            self.MVOL_OWNCLOUD_USER,
-            "files",
-            self.MVOL_OWNCLOUD_SUBPATH,
+            self.MVOL_ROOT,
             "mvol",
             identifier.split("-")[1],
             identifier.split("-")[2],
@@ -260,17 +254,11 @@ class MvolLayer4StorageInterface(StorageInterface):
             return True
 
     def __init__(self, conf):
-        self.MVOL_OWNCLOUD_ROOT = conf['MVOL_OWNCLOUD_ROOT']
-        self.MVOL_OWNCLOUD_USER = conf['MVOL_OWNCLOUD_USER']
-        self.MVOL_OWNCLOUD_SUBPATH = conf['MVOL_OWNCLOUD_SUBPATH']
+        self.MVOL_ROOT = conf['MVOL_ROOT']
 
     def build_dir_path(self, identifier):
         return join(
-            self.MVOL_OWNCLOUD_ROOT,
-            "data",
-            self.MVOL_OWNCLOUD_USER,
-            "files",
-            self.MVOL_OWNCLOUD_SUBPATH,
+            self.MVOL_ROOT,
             "mvol",
             identifier.split("-")[1],
             identifier.split("-")[2],

--- a/tests/test_digcollretriever.py
+++ b/tests/test_digcollretriever.py
@@ -18,9 +18,8 @@ class Tests(unittest.TestCase):
     def setUp(self):
         self.app = digcollretriever.app.test_client()
         digcollretriever.blueprint.BLUEPRINT.config = {
-            "MVOL_OWNCLOUD_ROOT": join(getcwd(), "sandbox", "mock_oc_root"),
-            "MVOL_OWNCLOUD_USER": "ldr_oc_admin",
-            "MVOL_OWNCLOUD_SUBPATH": "Preservation Unit",
+            "MVOL_ROOT": join(getcwd(), "sandbox", "mock_oc_root", "data", "ldr_oc_admin",
+                              "files", "Preservation Unit"),
             "DEBUG": True
         }
 


### PR DESCRIPTION
Changes the MVOL storage interfaces such that they are blind to what the mvols are being stored in (eg, owncloud, in our case). Instead of providing OC specific information that environmental variable (it is now singular) is just the full path to the directory that contains ```mvol```.

The README has been updated to reflect this - as well as remove mention of POS ocr metadata, which (if I am not mistaken) is no longer on the roadmap.